### PR TITLE
Update HACS manifest and prep for HACS default repo inclusion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: "Release"
+
+on:
+  release:
+    types:
+      - published
+permissions:
+  contents: write
+  packages: write
+
+
+jobs:
+  release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create zip file
+        run: |
+          cd custom_components/ha_jokes
+          zip -r ../../secretsentry.zip . -x "__pycache__/*" "*.pyc" "*.pyo"
+
+      - name: Upload zip to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./secretsentry.zip
+          asset_name: secretsentry.zip
+          tag: ${{ github.event.release.tag_name }}
+          overwrite: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,20 @@
+name: "Validate"
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - name: HACS validation
+        uses: "hacs/action@main"
+        with:
+          category: "integration"
+          ignore: brands
+      - name: Hassfest validation
+        uses: "home-assistant/actions/hassfest@master"

--- a/custom_components/secretsentry/manifest.json
+++ b/custom_components/secretsentry/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "secretsentry",
   "name": "SecretSentry",
-  "codeowners": ["@secretsentry"],
+  "codeowners": ["@HallyAus"],
   "config_flow": true,
-  "documentation": "https://github.com/secretsentry/secretsentry",
+  "documentation": "https://github.com/HallyAus/SecretSentry/",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/secretsentry/secretsentry/issues",
-  "version": "3.0.6",
+  "issue_tracker": "hhttps://github.com/HallyAus/SecretSentry/issues",
+  "version": "3.0.8",
   "requirements": [],
   "dependencies": [],
   "integration_type": "service"


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows for release automation and validation, and updates the `manifest.json` metadata for the `secretsentry` integration. The changes streamline the release process, add automated validation, and update ownership and documentation details.

**CI/CD and Automation:**

* Added a `release.yml` workflow to automatically package the integration as a zip file and upload it to GitHub Releases when a release is published. (.github/workflows/release.yml)
* Added a `validate.yml` workflow to run HACS and Hassfest validations on pushes, pull requests, and a nightly schedule, improving code quality and compliance. (.github/workflows/validate.yml)

**Metadata and Ownership Updates:**

* Updated `manifest.json` to change the `codeowners`, documentation URL, and issue tracker URL to `HallyAus`, and bumped the version to `3.0.8`. (custom_components/secretsentry/manifest.json)
(version bump is in anticipation of next release, given current version is actually 3.0.7 but HACS reports it as 3.0.6)