### PR TITLE
Fix SecretSentry open issues for v3.0.8

### DIFF
--- a/custom_components/secretsentry/config_flow.py
+++ b/custom_components/secretsentry/config_flow.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, OptionsFlow, ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.core import callback
 
-_LOGGER = logging.getLogger(__name__)
+from .const import CONF_ENABLE_EXTERNAL_CHECK, CONF_EXTERNAL_URL, DOMAIN
 
-DOMAIN = "secretsentry"
+_LOGGER = logging.getLogger(__name__)
 
 
 class SecretSentryConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -52,6 +53,8 @@ class SecretSentryOptionsFlowHandler(OptionsFlow):
             "privacy_mode_reports": True,
             "enable_log_scan": False,
             "enable_env_hygiene": True,
+            CONF_ENABLE_EXTERNAL_CHECK: False,
+            CONF_EXTERNAL_URL: "",
             "scan_interval": "daily",
             "max_file_size_kb": 512,
             "max_total_scan_mb": 50,
@@ -59,23 +62,45 @@ class SecretSentryOptionsFlowHandler(OptionsFlow):
         }
         options = {**defaults, **dict(self._entry.options or {})}
 
-        if user_input is None:
-            try:
-                schema = vol.Schema({
-                    vol.Required("privacy_mode_reports", default=options["privacy_mode_reports"]): bool,
-                    vol.Required("enable_log_scan", default=options["enable_log_scan"]): bool,
-                    vol.Required("enable_env_hygiene", default=options["enable_env_hygiene"]): bool,
-                    vol.Required("scan_interval", default=options["scan_interval"]): vol.In(["disabled", "daily", "weekly"]),
-                    vol.Required("max_file_size_kb", default=options["max_file_size_kb"]): int,
-                    vol.Required("max_total_scan_mb", default=options["max_total_scan_mb"]): int,
-                    vol.Required("max_findings", default=options["max_findings"]): int,
-                })
-                return self.async_show_form(step_id="settings", data_schema=schema)
-            except Exception:
-                _LOGGER.exception("Options flow failed")
-                return self.async_show_form(step_id="settings", data_schema=vol.Schema({}))
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            external_url = str(user_input.get(CONF_EXTERNAL_URL, "")).strip()
+            if user_input.get(CONF_ENABLE_EXTERNAL_CHECK):
+                parsed = urlparse(external_url)
+                if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                    errors[CONF_EXTERNAL_URL] = "invalid_url"
+                else:
+                    user_input[CONF_EXTERNAL_URL] = external_url
 
-        return self.async_create_entry(title="", data={**options, **user_input})
+            if not errors:
+                return self.async_create_entry(title="", data={**options, **user_input})
+
+        try:
+            schema = vol.Schema({
+                vol.Required("privacy_mode_reports", default=options["privacy_mode_reports"]): bool,
+                vol.Required("enable_log_scan", default=options["enable_log_scan"]): bool,
+                vol.Required("enable_env_hygiene", default=options["enable_env_hygiene"]): bool,
+                vol.Required(
+                    CONF_ENABLE_EXTERNAL_CHECK,
+                    default=options[CONF_ENABLE_EXTERNAL_CHECK],
+                ): bool,
+                vol.Optional(
+                    CONF_EXTERNAL_URL,
+                    default=options[CONF_EXTERNAL_URL],
+                ): str,
+                vol.Required("scan_interval", default=options["scan_interval"]): vol.In(["disabled", "daily", "weekly"]),
+                vol.Required("max_file_size_kb", default=options["max_file_size_kb"]): int,
+                vol.Required("max_total_scan_mb", default=options["max_total_scan_mb"]): int,
+                vol.Required("max_findings", default=options["max_findings"]): int,
+            })
+            return self.async_show_form(
+                step_id="settings",
+                data_schema=schema,
+                errors=errors,
+            )
+        except Exception:
+            _LOGGER.exception("Options flow failed")
+            return self.async_show_form(step_id="settings", data_schema=vol.Schema({}))
 
     async def async_step_scan_now(self, user_input: dict[str, Any] | None = None):
         """Trigger an immediate scan."""

--- a/custom_components/secretsentry/const.py
+++ b/custom_components/secretsentry/const.py
@@ -222,9 +222,11 @@ ARCHIVE_EXTENSIONS: Final[tuple[str, ...]] = (
     ".zip",
 )
 
-# Directories to skip during scanning
+# Directories to skip during scanning. .cloud is Home Assistant/Nabu Casa managed
+# credential state; flagging it creates findings the user cannot safely remediate.
 DEFAULT_EXCLUDE_DIRS: Final[tuple[str, ...]] = (
     ".storage",
+    ".cloud",
     "deps",
     "tts",
     "www",
@@ -283,9 +285,11 @@ DEFAULT_OPTIONS: Final[dict[str, any]] = {
     "privacy_mode_reports": True,
     "enable_log_scan": False,
     "enable_env_hygiene": True,
+    "enable_external_url_self_check": False,
+    "external_url": "",
     "scan_interval": "daily",
     "include_paths": [],
-    "exclude_paths": [".storage", "deps", "tts", "www", "media", "backups", "backup", "logs", "__pycache__"],
+    "exclude_paths": [".storage", ".cloud", "deps", "tts", "www", "media", "backups", "backup", "logs", "__pycache__"],
     "max_file_size_kb": 512,
     "max_total_scan_mb": 50,
     "max_findings": 500,

--- a/custom_components/secretsentry/coordinator.py
+++ b/custom_components/secretsentry/coordinator.py
@@ -126,7 +126,12 @@ class SecretSentryData:
             "resolved_count": self.resolved_count,
         }
         if self.external_check_result:
-            base["external_self_check"] = self.external_check_result
+            external_result = dict(self.external_check_result)
+            external_result["findings"] = [
+                finding.to_dict() if hasattr(finding, "to_dict") else finding
+                for finding in external_result.get("findings", [])
+            ]
+            base["external_self_check"] = external_result
         return base
 
 

--- a/custom_components/secretsentry/http_check.py
+++ b/custom_components/secretsentry/http_check.py
@@ -147,5 +147,7 @@ async def check_external_url(
         _LOGGER.warning("External URL check error: %s", err)
         results["error"] = str(err)
 
-    results["findings"] = [f.to_dict() for f in findings]
+    # Keep Finding objects internally so repairs/grouping can consume them.
+    # SecretSentryData.to_dict() converts them at the JSON/export boundary.
+    results["findings"] = findings
     return results

--- a/custom_components/secretsentry/manifest.json
+++ b/custom_components/secretsentry/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "secretsentry",
   "name": "SecretSentry",
-  "codeowners": ["@secretsentry"],
+  "codeowners": ["@HallyAus"],
   "config_flow": true,
-  "documentation": "https://github.com/secretsentry/secretsentry",
+  "documentation": "https://github.com/HallyAus/SecretSentry",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/secretsentry/secretsentry/issues",
-  "version": "3.0.6",
+  "issue_tracker": "https://github.com/HallyAus/SecretSentry/issues",
+  "version": "3.0.8",
   "requirements": [],
   "dependencies": [],
   "integration_type": "service"

--- a/custom_components/secretsentry/rules.py
+++ b/custom_components/secretsentry/rules.py
@@ -124,6 +124,27 @@ class ScanContext:
     secret_usage_map: dict[str, list[tuple[str, int]]] = field(
         default_factory=dict
     )  # key -> [(file, line), ...]
+    secret_store_keys: dict[str, set[str]] = field(
+        default_factory=dict
+    )  # relative directory -> keys defined by that directory's secrets.yaml
+
+    def available_secret_keys_for(self, file_path: str) -> set[str]:
+        """Return secret keys visible to a config file.
+
+        Home Assistant-style nested secret stores apply to files in their own
+        subtree while the root store remains an ancestor fallback. Sibling
+        stores must never satisfy one another's references.
+        """
+        path = Path(file_path)
+        current = path.parent
+        available: set[str] = set()
+        while True:
+            key = "." if str(current) in ("", ".") else current.as_posix()
+            available.update(self.secret_store_keys.get(key, set()))
+            if key == ".":
+                break
+            current = current.parent
+        return available
 
 
 class Rule(ABC):
@@ -464,16 +485,15 @@ class R004SecretRefMissing(Rule):
         findings: list[Finding] = []
 
         try:
-            available_keys = set(context.secrets_map.keys())
-
             for key in context.used_secret_keys:
-                if key not in available_keys:
-                    # Get first usage location
-                    locations = context.secret_usage_map.get(key, [])
-                    if locations:
-                        file_path, line_num = locations[0]
-                    else:
-                        file_path, line_num = "unknown", None
+                locations = context.secret_usage_map.get(key, [])
+                missing_locations = [
+                    (file_path, line_num)
+                    for file_path, line_num in locations
+                    if key not in context.available_secret_keys_for(file_path)
+                ]
+                if missing_locations:
+                    file_path, line_num = missing_locations[0]
 
                     findings.append(
                         Finding(

--- a/custom_components/secretsentry/scanner.py
+++ b/custom_components/secretsentry/scanner.py
@@ -298,28 +298,45 @@ class SecretSentryScanner:
         Returns:
             Initialized ScanContext.
         """
-        # Load secrets.yaml
+        # Load root and nested secrets.yaml files. ESPHome and other packages can
+        # maintain their own secret stores, so all non-excluded stores contribute
+        # available keys for !secret validation.
         secrets_map: dict[str, str] = {}
         secrets_raw_hashes: dict[str, str] = {}
 
-        secrets_path = self.config_path / "secrets.yaml"
-        if secrets_path.exists():
-            try:
-                import yaml
+        try:
+            import yaml
 
-                content = secrets_path.read_text(encoding="utf-8")
-                parsed = yaml.safe_load(content)
-                if isinstance(parsed, dict):
-                    for key, value in parsed.items():
-                        if isinstance(value, str):
-                            # Store masked version and hash only
-                            secrets_map[key] = mask_secret(value)
-                            secrets_raw_hashes[key] = hash_for_comparison(value)
-                        else:
-                            secrets_map[key] = str(type(value))
-            except Exception as err:
-                _LOGGER.warning("Failed to load secrets.yaml: %s", err)
-                self._errors.append(f"Failed to load secrets.yaml: {err}")
+            for secrets_path in self.config_path.rglob("secrets.yaml"):
+                try:
+                    rel_path = secrets_path.relative_to(self.config_path)
+                    if any(
+                        part in DEFAULT_EXCLUDE_DIRS
+                        for part in rel_path.parts[:-1]
+                    ):
+                        continue
+
+                    content = secrets_path.read_text(encoding="utf-8")
+                    parsed = yaml.safe_load(content)
+                    if isinstance(parsed, dict):
+                        for key, value in parsed.items():
+                            key = str(key)
+                            if isinstance(value, str):
+                                # Store masked version and hash only
+                                secrets_map.setdefault(key, mask_secret(value))
+                                secrets_raw_hashes.setdefault(
+                                    key, hash_for_comparison(value)
+                                )
+                            else:
+                                secrets_map.setdefault(key, str(type(value)))
+                except Exception as err:
+                    _LOGGER.warning("Failed to load %s: %s", secrets_path, err)
+                    self._errors.append(
+                        f"Failed to load {secrets_path.name}: {err}"
+                    )
+        except Exception as err:
+            _LOGGER.warning("Failed to enumerate secrets.yaml files: %s", err)
+            self._errors.append(f"Failed to enumerate secrets.yaml files: {err}")
 
         # Load .gitignore
         gitignore_text: str | None = None
@@ -369,8 +386,14 @@ class SecretSentryScanner:
                 if part in exclude_dirs:
                     return True
 
-            # Check file pattern exclusions
+            # secrets.yaml files are intentionally secret stores. Their keys are
+            # loaded separately into the scan context, while their raw values must
+            # not be treated as inline leaks.
             filename = path.name
+            if filename.lower() == "secrets.yaml":
+                return True
+
+            # Check file pattern exclusions
             for pattern in DEFAULT_EXCLUDE_PATTERNS:
                 if fnmatch.fnmatch(filename, pattern):
                     return True
@@ -391,7 +414,8 @@ class SecretSentryScanner:
                 continue
 
             if scan_root.is_file():
-                yield scan_root
+                if not should_skip(scan_root):
+                    yield scan_root
                 continue
 
             try:

--- a/custom_components/secretsentry/scanner.py
+++ b/custom_components/secretsentry/scanner.py
@@ -219,8 +219,14 @@ class SecretSentryScanner:
                 content = file_path.read_text(encoding="utf-8", errors="ignore")
                 lines = content.splitlines()
 
+                # Root secrets.yaml is intentionally available for secret-age
+                # metadata, but must not be fed to leak-oriented rules.
+                is_root_secrets = rel_path == "secrets.yaml"
+
                 # Run each rule on the file
                 for rule in self._rules:
+                    if is_root_secrets and rule.id != RuleID.R060_SECRET_AGE:
+                        continue
                     try:
                         rule_findings = rule.evaluate_file_text(
                             rel_path, lines, context
@@ -298,11 +304,12 @@ class SecretSentryScanner:
         Returns:
             Initialized ScanContext.
         """
-        # Load root and nested secrets.yaml files. ESPHome and other packages can
-        # maintain their own secret stores, so all non-excluded stores contribute
-        # available keys for !secret validation.
+        # Load root and nested secrets.yaml files. Keep raw-value hashes and
+        # inventory metadata only for the root store, while nested stores contribute
+        # scoped key names for !secret validation without leaking values across trees.
         secrets_map: dict[str, str] = {}
         secrets_raw_hashes: dict[str, str] = {}
+        secret_store_keys: dict[str, set[str]] = {}
 
         try:
             import yaml
@@ -319,16 +326,20 @@ class SecretSentryScanner:
                     content = secrets_path.read_text(encoding="utf-8")
                     parsed = yaml.safe_load(content)
                     if isinstance(parsed, dict):
-                        for key, value in parsed.items():
-                            key = str(key)
-                            if isinstance(value, str):
-                                # Store masked version and hash only
-                                secrets_map.setdefault(key, mask_secret(value))
-                                secrets_raw_hashes.setdefault(
-                                    key, hash_for_comparison(value)
-                                )
-                            else:
-                                secrets_map.setdefault(key, str(type(value)))
+                        store_dir = rel_path.parent
+                        store_key = "." if str(store_dir) in ("", ".") else store_dir.as_posix()
+                        secret_store_keys[store_key] = {str(key) for key in parsed}
+
+                        # Root secrets.yaml drives inventory/duplication/age metadata.
+                        # Nested stores expose key names only, scoped to their subtree.
+                        if store_key == ".":
+                            for key, value in parsed.items():
+                                key = str(key)
+                                if isinstance(value, str):
+                                    secrets_map[key] = mask_secret(value)
+                                    secrets_raw_hashes[key] = hash_for_comparison(value)
+                                else:
+                                    secrets_map[key] = str(type(value))
                 except Exception as err:
                     _LOGGER.warning("Failed to load %s: %s", secrets_path, err)
                     self._errors.append(
@@ -355,6 +366,7 @@ class SecretSentryScanner:
             gitignore_text=gitignore_text,
             options=self.options,
             last_scan_fingerprints=last_fingerprints,
+            secret_store_keys=secret_store_keys,
         )
 
     def _get_scannable_files(self) -> Generator[Path, None, None]:
@@ -390,7 +402,7 @@ class SecretSentryScanner:
             # loaded separately into the scan context, while their raw values must
             # not be treated as inline leaks.
             filename = path.name
-            if filename.lower() == "secrets.yaml":
+            if filename.lower() == "secrets.yaml" and rel_path.as_posix() != "secrets.yaml":
                 return True
 
             # Check file pattern exclusions

--- a/custom_components/secretsentry/scanner.py
+++ b/custom_components/secretsentry/scanner.py
@@ -138,7 +138,7 @@ class ScanResult:
             },
             "findings": [f.to_dict() for f in self.findings],
             "secret_inventory": self.secret_inventory,
-            "errors": self.errors[:10],  # Limit errors in export
+            "errors": self.errors[:10],
         }
 
 
@@ -150,39 +150,22 @@ class SecretSentryScanner:
         config_path: str,
         options: dict[str, Any] | None = None,
     ) -> None:
-        """Initialize the scanner.
-
-        Args:
-            config_path: Path to the Home Assistant config directory.
-            options: Scanner options from config entry.
-        """
+        """Initialize the scanner."""
         self.config_path = Path(config_path)
         self.options = options or {}
         self._rules = get_all_rules()
-        self._log_rule = R080LogContainsSecret()  # v3.0: dedicated log rule
+        self._log_rule = R080LogContainsSecret()
         self._errors: list[str] = []
 
     def scan(
         self,
         last_fingerprints: set[str] | None = None,
     ) -> ScanResult:
-        """Run the security scan.
-
-        This method should be called from an executor.
-
-        Args:
-            last_fingerprints: Fingerprints from previous scan for delta.
-
-        Returns:
-            ScanResult with all findings.
-        """
+        """Run the security scan."""
         start_time = datetime.now()
         self._errors = []
-
-        # Initialize context
         context = self._create_context(last_fingerprints or set())
 
-        # Collect all findings
         findings: list[Finding] = []
         scanned_files = 0
         scanned_bytes = 0
@@ -195,7 +178,6 @@ class SecretSentryScanner:
         ) * 1024 * 1024
         max_findings = self.options.get("max_findings", DEFAULT_MAX_FINDINGS)
 
-        # Scan regular files
         for file_path in self._get_scannable_files():
             if len(findings) >= max_findings:
                 _LOGGER.warning(
@@ -219,12 +201,9 @@ class SecretSentryScanner:
                 content = file_path.read_text(encoding="utf-8", errors="ignore")
                 lines = content.splitlines()
 
-                # Run each rule on the file
                 for rule in self._rules:
                     try:
-                        rule_findings = rule.evaluate_file_text(
-                            rel_path, lines, context
-                        )
+                        rule_findings = rule.evaluate_file_text(rel_path, lines, context)
                         findings.extend(rule_findings)
                     except Exception as err:
                         _LOGGER.debug(
@@ -241,22 +220,18 @@ class SecretSentryScanner:
             except Exception as err:
                 _LOGGER.debug("Unexpected error scanning %s: %s", file_path, err)
 
-        # v3.0: Scan environment files if enabled
         if self.options.get(CONF_ENABLE_ENV_HYGIENE, DEFAULT_ENABLE_ENV_HYGIENE):
             env_findings = self._scan_env_files(context, max_findings - len(findings))
             findings.extend(env_findings)
 
-        # Scan archives if enabled
         if self.options.get("enable_snapshot_scan"):
             archive_findings = self._scan_archives(context, max_findings - len(findings))
             findings.extend(archive_findings)
 
-        # v3.0: Scan logs if enabled
         if self.options.get(CONF_ENABLE_LOG_SCAN, DEFAULT_ENABLE_LOG_SCAN):
             log_findings = self._scan_logs(context, max_findings - len(findings))
             findings.extend(log_findings)
 
-        # Run context-level evaluations
         for rule in self._rules:
             try:
                 context_findings = rule.evaluate_context(context)
@@ -264,9 +239,7 @@ class SecretSentryScanner:
             except Exception as err:
                 _LOGGER.debug("Rule %s context error: %s", rule.id, err)
 
-        # Build secret inventory
         secret_inventory = self._build_secret_inventory(context)
-
         end_time = datetime.now()
         scan_duration = (end_time - start_time).total_seconds()
 
@@ -290,38 +263,52 @@ class SecretSentryScanner:
         self,
         last_fingerprints: set[str],
     ) -> ScanContext:
-        """Create the scan context.
+        """Create the scan context and load every Home Assistant secret store.
 
-        Args:
-            last_fingerprints: Fingerprints from previous scan.
-
-        Returns:
-            Initialized ScanContext.
+        Home Assistant packages such as ESPHome can maintain a local secrets.yaml.
+        Treating only /config/secrets.yaml as authoritative creates false R004
+        findings, so all non-excluded secrets.yaml files contribute available keys.
+        Raw values are never retained: only masked values and comparison hashes are
+        stored in the scan context.
         """
-        # Load secrets.yaml
         secrets_map: dict[str, str] = {}
         secrets_raw_hashes: dict[str, str] = {}
 
-        secrets_path = self.config_path / "secrets.yaml"
-        if secrets_path.exists():
-            try:
-                import yaml
+        try:
+            import yaml
 
-                content = secrets_path.read_text(encoding="utf-8")
-                parsed = yaml.safe_load(content)
-                if isinstance(parsed, dict):
+            for secrets_path in self.config_path.rglob("secrets.yaml"):
+                try:
+                    rel_path = secrets_path.relative_to(self.config_path)
+                except ValueError:
+                    continue
+
+                if any(part in DEFAULT_EXCLUDE_DIRS for part in rel_path.parts[:-1]):
+                    continue
+
+                try:
+                    content = secrets_path.read_text(encoding="utf-8")
+                    parsed = yaml.safe_load(content)
+                    if not isinstance(parsed, dict):
+                        continue
+
                     for key, value in parsed.items():
+                        key_str = str(key)
                         if isinstance(value, str):
-                            # Store masked version and hash only
-                            secrets_map[key] = mask_secret(value)
-                            secrets_raw_hashes[key] = hash_for_comparison(value)
+                            secrets_map.setdefault(key_str, mask_secret(value))
+                            secrets_raw_hashes.setdefault(
+                                key_str, hash_for_comparison(value)
+                            )
                         else:
-                            secrets_map[key] = str(type(value))
-            except Exception as err:
-                _LOGGER.warning("Failed to load secrets.yaml: %s", err)
-                self._errors.append(f"Failed to load secrets.yaml: {err}")
+                            secrets_map.setdefault(key_str, str(type(value)))
+                except Exception as err:
+                    rel_display = str(rel_path)
+                    _LOGGER.warning("Failed to load %s: %s", rel_display, err)
+                    self._errors.append(f"Failed to load {rel_display}: {err}")
+        except Exception as err:
+            _LOGGER.warning("Failed to enumerate secrets.yaml files: %s", err)
+            self._errors.append(f"Failed to enumerate secrets.yaml files: {err}")
 
-        # Load .gitignore
         gitignore_text: str | None = None
         gitignore_path = self.config_path / ".gitignore"
         if gitignore_path.exists():
@@ -341,16 +328,10 @@ class SecretSentryScanner:
         )
 
     def _get_scannable_files(self) -> Generator[Path, None, None]:
-        """Get all files that should be scanned.
-
-        Yields:
-            Path objects for each file to scan.
-        """
-        # Get custom include/exclude paths
+        """Get all files that should be scanned."""
         include_paths = self.options.get("include_paths", [])
         exclude_paths = self.options.get("exclude_paths", [])
 
-        # Combine with defaults
         exclude_dirs = set(DEFAULT_EXCLUDE_DIRS)
         for path in exclude_paths:
             exclude_dirs.add(path)
@@ -363,21 +344,23 @@ class SecretSentryScanner:
                 return True
 
             parts = rel_path.parts
-
-            # Check directory exclusions
-            for part in parts[:-1]:  # Check parent dirs
+            for part in parts[:-1]:
                 if part in exclude_dirs:
                     return True
 
-            # Check file pattern exclusions
             filename = path.name
+
+            # secrets.yaml is intentionally a secret store, not an inline-secret
+            # leak source. Its keys are loaded separately into the scan context.
+            if filename.lower() == "secrets.yaml":
+                return True
+
             for pattern in DEFAULT_EXCLUDE_PATTERNS:
                 if fnmatch.fnmatch(filename, pattern):
                     return True
 
             return False
 
-        # Scan based on include paths or default to config root
         scan_roots = [self.config_path]
         if include_paths:
             scan_roots = [
@@ -391,7 +374,8 @@ class SecretSentryScanner:
                 continue
 
             if scan_root.is_file():
-                yield scan_root
+                if not should_skip(scan_root):
+                    yield scan_root
                 continue
 
             try:
@@ -402,7 +386,6 @@ class SecretSentryScanner:
                     if should_skip(path):
                         continue
 
-                    # Check extension
                     suffix = path.suffix.lower()
                     if suffix not in SCANNABLE_EXTENSIONS:
                         continue
@@ -418,17 +401,7 @@ class SecretSentryScanner:
         context: ScanContext,
         max_findings: int,
     ) -> list[Finding]:
-        """Scan environment files (.env, docker-compose.yml).
-
-        v3.0: Added environment hygiene checks.
-
-        Args:
-            context: Scan context.
-            max_findings: Maximum findings to return.
-
-        Returns:
-            List of findings from env files.
-        """
+        """Scan environment files (.env, docker-compose.yml)."""
         findings: list[Finding] = []
         env_files = self.options.get(CONF_ENV_FILES, DEFAULT_ENV_FILES)
 
@@ -445,7 +418,6 @@ class SecretSentryScanner:
                 content = file_path.read_text(encoding="utf-8", errors="ignore")
                 lines = content.splitlines()
 
-                # Run rules on env file
                 for rule in self._rules:
                     if len(findings) >= max_findings:
                         break
@@ -465,17 +437,7 @@ class SecretSentryScanner:
         context: ScanContext,
         max_findings: int,
     ) -> list[Finding]:
-        """Scan log files for secrets (v3.0).
-
-        Streams lines to avoid loading entire log into memory.
-
-        Args:
-            context: Scan context.
-            max_findings: Maximum findings to return.
-
-        Returns:
-            List of findings from log files.
-        """
+        """Scan log files for secrets (v3.0)."""
         findings: list[Finding] = []
         log_paths = self.options.get(CONF_LOG_SCAN_PATHS, DEFAULT_LOG_SCAN_PATHS)
         max_log_mb = self.options.get(CONF_MAX_LOG_SCAN_MB, DEFAULT_MAX_LOG_SCAN_MB)
@@ -496,7 +458,6 @@ class SecretSentryScanner:
                     _LOGGER.debug("Log file %s exceeds max size, skipping", log_path)
                     continue
 
-                # Stream log file line by line
                 lines_read = 0
                 batch_lines: list[str] = []
                 batch_start_line = 1
@@ -511,12 +472,10 @@ class SecretSentryScanner:
                         lines_read += 1
                         batch_lines.append(line.rstrip("\n\r"))
 
-                        # Process in batches of 1000 lines
                         if len(batch_lines) >= 1000:
                             batch_findings = self._log_rule.evaluate_file_text(
                                 log_path, batch_lines, context
                             )
-                            # Adjust line numbers for batch
                             for bf in batch_findings:
                                 if bf.line:
                                     bf.line = batch_start_line + bf.line - 1
@@ -524,7 +483,6 @@ class SecretSentryScanner:
                             batch_start_line = line_num + 1
                             batch_lines = []
 
-                    # Process remaining lines
                     if batch_lines and len(findings) < max_findings:
                         batch_findings = self._log_rule.evaluate_file_text(
                             log_path, batch_lines, context
@@ -544,18 +502,9 @@ class SecretSentryScanner:
         context: ScanContext,
         max_findings: int,
     ) -> list[Finding]:
-        """Scan backup archives for secrets.
-
-        Args:
-            context: Scan context.
-            max_findings: Maximum findings to return.
-
-        Returns:
-            List of findings from archives.
-        """
+        """Scan backup archives for secrets."""
         findings: list[Finding] = []
 
-        # Look for archives in backup directories
         backup_dirs = ["backups", "backup"]
         for backup_dir in backup_dirs:
             backup_path = self.config_path / backup_dir
@@ -588,15 +537,7 @@ class SecretSentryScanner:
         archive_path: Path,
         context: ScanContext,
     ) -> list[Finding]:
-        """Scan a single archive file.
-
-        Args:
-            archive_path: Path to the archive.
-            context: Scan context.
-
-        Returns:
-            List of findings.
-        """
+        """Scan a single archive file."""
         findings: list[Finding] = []
         rel_archive = str(archive_path.relative_to(self.config_path))
         total_read = 0
@@ -607,7 +548,6 @@ class SecretSentryScanner:
             """Check archive member content for secrets."""
             lines = content.splitlines()
             for line_num, line in enumerate(lines, start=1):
-                # Check for JWT
                 if JWT_PATTERN.search(line):
                     findings.append(
                         Finding(
@@ -623,9 +563,8 @@ class SecretSentryScanner:
                             tags=["backup", "secrets"],
                         )
                     )
-                    return  # One finding per member is enough
+                    return
 
-                # Check for PEM
                 if PEM_BEGIN_PATTERN.search(line):
                     findings.append(
                         Finding(
@@ -643,7 +582,6 @@ class SecretSentryScanner:
                     )
                     return
 
-                # v3.0: Check for URL userinfo
                 if URL_USERINFO_PATTERN.search(line):
                     findings.append(
                         Finding(
@@ -674,7 +612,6 @@ class SecretSentryScanner:
                         if info.is_dir():
                             continue
 
-                        # Only check text-like files
                         name_lower = info.filename.lower()
                         if not any(name_lower.endswith(ext) for ext in SCANNABLE_EXTENSIONS):
                             continue
@@ -715,23 +652,14 @@ class SecretSentryScanner:
         return findings
 
     def _build_secret_inventory(self, context: ScanContext) -> dict[str, Any]:
-        """Build the secret inventory for reporting.
-
-        Args:
-            context: Scan context after scanning.
-
-        Returns:
-            Secret inventory dictionary.
-        """
+        """Build the secret inventory for reporting."""
         defined_keys = set(context.secrets_map.keys())
         used_keys = context.used_secret_keys
         unused_keys = defined_keys - used_keys
         missing_keys = used_keys - defined_keys
 
-        # Build blast radius (capped)
         blast_radius: dict[str, list[str]] = {}
         for key, locations in context.secret_usage_map.items():
-            # Cap at 10 locations per key
             blast_radius[key] = [f"{f}:{l}" for f, l in locations[:10]]
             if len(locations) > 10:
                 blast_radius[key].append(f"...and {len(locations) - 10} more")
@@ -749,31 +677,15 @@ def create_sanitised_copy(
     output_dir: str,
     options: dict[str, Any] | None = None,
 ) -> tuple[int, list[str]]:
-    """Create a sanitised copy of configuration files.
-
-    This replaces detected secrets with ***REDACTED***.
-    v3.0: Also redacts URL userinfo and applies privacy mode.
-
-    Args:
-        config_path: Path to the config directory.
-        output_dir: Path for the sanitised output.
-        options: Scanner options.
-
-    Returns:
-        Tuple of (files_processed, error_list).
-    """
+    """Create a sanitised copy of configuration files."""
     options = options or {}
     config_root = Path(config_path)
     output_root = Path(output_dir)
 
-    # v3.0: Initialize privacy tokenizer if privacy mode is on
     privacy_mode = options.get(CONF_PRIVACY_MODE_REPORTS, DEFAULT_PRIVACY_MODE_REPORTS)
     tokenizer = PrivacyTokenizer() if privacy_mode else None
-
-    # Create output directory
     output_root.mkdir(parents=True, exist_ok=True)
 
-    # Write warning README
     readme_content = """# SecretSentry Sanitised Configuration Copy
 
 **WARNING**: This directory contains a sanitised copy of your Home Assistant
@@ -791,16 +703,12 @@ Generated: {timestamp}
     files_processed = 0
     errors: list[str] = []
 
-    # Patterns to redact
     sensitive_patterns = [
-        # Key-value patterns
         (
             r'(\b(?:api_key|apikey|token|password|secret|bearer|authorization|client_secret|private_key|access_token|refresh_token|auth_token|webhook|mqtt_password|db_password|database_url|redis_password|mysql_password|postgres_password|encryption_key|jwt_secret)\s*[:=]\s*)["\']?([^"\'\s\n]+)["\']?',
             r'\1"***REDACTED***"',
         ),
-        # JWT tokens
         (r'eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+', '***REDACTED_JWT***'),
-        # Webhook IDs (partial)
         (r'(/api/webhook/)[A-Za-z0-9_-]{8,}', r'\1***REDACTED***'),
     ]
 
@@ -808,26 +716,17 @@ Generated: {timestamp}
         try:
             rel_path = file_path.relative_to(config_root)
             output_path = output_root / rel_path
-
-            # Create parent directories
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Read and sanitise content
             content = file_path.read_text(encoding="utf-8", errors="ignore")
-
-            # Apply redaction patterns
             sanitised = content
             for pattern, replacement in sensitive_patterns:
                 sanitised = re.sub(pattern, replacement, sanitised, flags=re.IGNORECASE)
 
-            # v3.0: Redact URL userinfo
             sanitised = redact_url_userinfo(sanitised)
-
-            # v3.0: Apply privacy mode if enabled
             if tokenizer:
                 sanitised = tokenizer.apply_privacy_mode(sanitised)
 
-            # Write sanitised file
             output_path.write_text(sanitised, encoding="utf-8")
             files_processed += 1
 
@@ -843,17 +742,7 @@ def export_report_with_privacy(
     scan_result: ScanResult,
     options: dict[str, Any],
 ) -> dict[str, Any]:
-    """Export scan result with privacy mode applied.
-
-    v3.0: New function for privacy-aware exports.
-
-    Args:
-        scan_result: The scan result to export.
-        options: Options including privacy_mode_reports.
-
-    Returns:
-        Dictionary ready for JSON export.
-    """
+    """Export scan result with privacy mode applied."""
     result_dict = scan_result.to_dict()
 
     privacy_mode = options.get(CONF_PRIVACY_MODE_REPORTS, DEFAULT_PRIVACY_MODE_REPORTS)

--- a/custom_components/secretsentry/scanner.py
+++ b/custom_components/secretsentry/scanner.py
@@ -138,7 +138,7 @@ class ScanResult:
             },
             "findings": [f.to_dict() for f in self.findings],
             "secret_inventory": self.secret_inventory,
-            "errors": self.errors[:10],
+            "errors": self.errors[:10],  # Limit errors in export
         }
 
 
@@ -150,22 +150,39 @@ class SecretSentryScanner:
         config_path: str,
         options: dict[str, Any] | None = None,
     ) -> None:
-        """Initialize the scanner."""
+        """Initialize the scanner.
+
+        Args:
+            config_path: Path to the Home Assistant config directory.
+            options: Scanner options from config entry.
+        """
         self.config_path = Path(config_path)
         self.options = options or {}
         self._rules = get_all_rules()
-        self._log_rule = R080LogContainsSecret()
+        self._log_rule = R080LogContainsSecret()  # v3.0: dedicated log rule
         self._errors: list[str] = []
 
     def scan(
         self,
         last_fingerprints: set[str] | None = None,
     ) -> ScanResult:
-        """Run the security scan."""
+        """Run the security scan.
+
+        This method should be called from an executor.
+
+        Args:
+            last_fingerprints: Fingerprints from previous scan for delta.
+
+        Returns:
+            ScanResult with all findings.
+        """
         start_time = datetime.now()
         self._errors = []
+
+        # Initialize context
         context = self._create_context(last_fingerprints or set())
 
+        # Collect all findings
         findings: list[Finding] = []
         scanned_files = 0
         scanned_bytes = 0
@@ -178,6 +195,7 @@ class SecretSentryScanner:
         ) * 1024 * 1024
         max_findings = self.options.get("max_findings", DEFAULT_MAX_FINDINGS)
 
+        # Scan regular files
         for file_path in self._get_scannable_files():
             if len(findings) >= max_findings:
                 _LOGGER.warning(
@@ -201,9 +219,12 @@ class SecretSentryScanner:
                 content = file_path.read_text(encoding="utf-8", errors="ignore")
                 lines = content.splitlines()
 
+                # Run each rule on the file
                 for rule in self._rules:
                     try:
-                        rule_findings = rule.evaluate_file_text(rel_path, lines, context)
+                        rule_findings = rule.evaluate_file_text(
+                            rel_path, lines, context
+                        )
                         findings.extend(rule_findings)
                     except Exception as err:
                         _LOGGER.debug(
@@ -220,18 +241,22 @@ class SecretSentryScanner:
             except Exception as err:
                 _LOGGER.debug("Unexpected error scanning %s: %s", file_path, err)
 
+        # v3.0: Scan environment files if enabled
         if self.options.get(CONF_ENABLE_ENV_HYGIENE, DEFAULT_ENABLE_ENV_HYGIENE):
             env_findings = self._scan_env_files(context, max_findings - len(findings))
             findings.extend(env_findings)
 
+        # Scan archives if enabled
         if self.options.get("enable_snapshot_scan"):
             archive_findings = self._scan_archives(context, max_findings - len(findings))
             findings.extend(archive_findings)
 
+        # v3.0: Scan logs if enabled
         if self.options.get(CONF_ENABLE_LOG_SCAN, DEFAULT_ENABLE_LOG_SCAN):
             log_findings = self._scan_logs(context, max_findings - len(findings))
             findings.extend(log_findings)
 
+        # Run context-level evaluations
         for rule in self._rules:
             try:
                 context_findings = rule.evaluate_context(context)
@@ -239,7 +264,9 @@ class SecretSentryScanner:
             except Exception as err:
                 _LOGGER.debug("Rule %s context error: %s", rule.id, err)
 
+        # Build secret inventory
         secret_inventory = self._build_secret_inventory(context)
+
         end_time = datetime.now()
         scan_duration = (end_time - start_time).total_seconds()
 
@@ -263,52 +290,38 @@ class SecretSentryScanner:
         self,
         last_fingerprints: set[str],
     ) -> ScanContext:
-        """Create the scan context and load every Home Assistant secret store.
+        """Create the scan context.
 
-        Home Assistant packages such as ESPHome can maintain a local secrets.yaml.
-        Treating only /config/secrets.yaml as authoritative creates false R004
-        findings, so all non-excluded secrets.yaml files contribute available keys.
-        Raw values are never retained: only masked values and comparison hashes are
-        stored in the scan context.
+        Args:
+            last_fingerprints: Fingerprints from previous scan.
+
+        Returns:
+            Initialized ScanContext.
         """
+        # Load secrets.yaml
         secrets_map: dict[str, str] = {}
         secrets_raw_hashes: dict[str, str] = {}
 
-        try:
-            import yaml
+        secrets_path = self.config_path / "secrets.yaml"
+        if secrets_path.exists():
+            try:
+                import yaml
 
-            for secrets_path in self.config_path.rglob("secrets.yaml"):
-                try:
-                    rel_path = secrets_path.relative_to(self.config_path)
-                except ValueError:
-                    continue
-
-                if any(part in DEFAULT_EXCLUDE_DIRS for part in rel_path.parts[:-1]):
-                    continue
-
-                try:
-                    content = secrets_path.read_text(encoding="utf-8")
-                    parsed = yaml.safe_load(content)
-                    if not isinstance(parsed, dict):
-                        continue
-
+                content = secrets_path.read_text(encoding="utf-8")
+                parsed = yaml.safe_load(content)
+                if isinstance(parsed, dict):
                     for key, value in parsed.items():
-                        key_str = str(key)
                         if isinstance(value, str):
-                            secrets_map.setdefault(key_str, mask_secret(value))
-                            secrets_raw_hashes.setdefault(
-                                key_str, hash_for_comparison(value)
-                            )
+                            # Store masked version and hash only
+                            secrets_map[key] = mask_secret(value)
+                            secrets_raw_hashes[key] = hash_for_comparison(value)
                         else:
-                            secrets_map.setdefault(key_str, str(type(value)))
-                except Exception as err:
-                    rel_display = str(rel_path)
-                    _LOGGER.warning("Failed to load %s: %s", rel_display, err)
-                    self._errors.append(f"Failed to load {rel_display}: {err}")
-        except Exception as err:
-            _LOGGER.warning("Failed to enumerate secrets.yaml files: %s", err)
-            self._errors.append(f"Failed to enumerate secrets.yaml files: {err}")
+                            secrets_map[key] = str(type(value))
+            except Exception as err:
+                _LOGGER.warning("Failed to load secrets.yaml: %s", err)
+                self._errors.append(f"Failed to load secrets.yaml: {err}")
 
+        # Load .gitignore
         gitignore_text: str | None = None
         gitignore_path = self.config_path / ".gitignore"
         if gitignore_path.exists():
@@ -328,10 +341,16 @@ class SecretSentryScanner:
         )
 
     def _get_scannable_files(self) -> Generator[Path, None, None]:
-        """Get all files that should be scanned."""
+        """Get all files that should be scanned.
+
+        Yields:
+            Path objects for each file to scan.
+        """
+        # Get custom include/exclude paths
         include_paths = self.options.get("include_paths", [])
         exclude_paths = self.options.get("exclude_paths", [])
 
+        # Combine with defaults
         exclude_dirs = set(DEFAULT_EXCLUDE_DIRS)
         for path in exclude_paths:
             exclude_dirs.add(path)
@@ -344,23 +363,21 @@ class SecretSentryScanner:
                 return True
 
             parts = rel_path.parts
-            for part in parts[:-1]:
+
+            # Check directory exclusions
+            for part in parts[:-1]:  # Check parent dirs
                 if part in exclude_dirs:
                     return True
 
+            # Check file pattern exclusions
             filename = path.name
-
-            # secrets.yaml is intentionally a secret store, not an inline-secret
-            # leak source. Its keys are loaded separately into the scan context.
-            if filename.lower() == "secrets.yaml":
-                return True
-
             for pattern in DEFAULT_EXCLUDE_PATTERNS:
                 if fnmatch.fnmatch(filename, pattern):
                     return True
 
             return False
 
+        # Scan based on include paths or default to config root
         scan_roots = [self.config_path]
         if include_paths:
             scan_roots = [
@@ -374,8 +391,7 @@ class SecretSentryScanner:
                 continue
 
             if scan_root.is_file():
-                if not should_skip(scan_root):
-                    yield scan_root
+                yield scan_root
                 continue
 
             try:
@@ -386,6 +402,7 @@ class SecretSentryScanner:
                     if should_skip(path):
                         continue
 
+                    # Check extension
                     suffix = path.suffix.lower()
                     if suffix not in SCANNABLE_EXTENSIONS:
                         continue
@@ -401,7 +418,17 @@ class SecretSentryScanner:
         context: ScanContext,
         max_findings: int,
     ) -> list[Finding]:
-        """Scan environment files (.env, docker-compose.yml)."""
+        """Scan environment files (.env, docker-compose.yml).
+
+        v3.0: Added environment hygiene checks.
+
+        Args:
+            context: Scan context.
+            max_findings: Maximum findings to return.
+
+        Returns:
+            List of findings from env files.
+        """
         findings: list[Finding] = []
         env_files = self.options.get(CONF_ENV_FILES, DEFAULT_ENV_FILES)
 
@@ -418,6 +445,7 @@ class SecretSentryScanner:
                 content = file_path.read_text(encoding="utf-8", errors="ignore")
                 lines = content.splitlines()
 
+                # Run rules on env file
                 for rule in self._rules:
                     if len(findings) >= max_findings:
                         break
@@ -437,7 +465,17 @@ class SecretSentryScanner:
         context: ScanContext,
         max_findings: int,
     ) -> list[Finding]:
-        """Scan log files for secrets (v3.0)."""
+        """Scan log files for secrets (v3.0).
+
+        Streams lines to avoid loading entire log into memory.
+
+        Args:
+            context: Scan context.
+            max_findings: Maximum findings to return.
+
+        Returns:
+            List of findings from log files.
+        """
         findings: list[Finding] = []
         log_paths = self.options.get(CONF_LOG_SCAN_PATHS, DEFAULT_LOG_SCAN_PATHS)
         max_log_mb = self.options.get(CONF_MAX_LOG_SCAN_MB, DEFAULT_MAX_LOG_SCAN_MB)
@@ -458,6 +496,7 @@ class SecretSentryScanner:
                     _LOGGER.debug("Log file %s exceeds max size, skipping", log_path)
                     continue
 
+                # Stream log file line by line
                 lines_read = 0
                 batch_lines: list[str] = []
                 batch_start_line = 1
@@ -472,10 +511,12 @@ class SecretSentryScanner:
                         lines_read += 1
                         batch_lines.append(line.rstrip("\n\r"))
 
+                        # Process in batches of 1000 lines
                         if len(batch_lines) >= 1000:
                             batch_findings = self._log_rule.evaluate_file_text(
                                 log_path, batch_lines, context
                             )
+                            # Adjust line numbers for batch
                             for bf in batch_findings:
                                 if bf.line:
                                     bf.line = batch_start_line + bf.line - 1
@@ -483,6 +524,7 @@ class SecretSentryScanner:
                             batch_start_line = line_num + 1
                             batch_lines = []
 
+                    # Process remaining lines
                     if batch_lines and len(findings) < max_findings:
                         batch_findings = self._log_rule.evaluate_file_text(
                             log_path, batch_lines, context
@@ -502,9 +544,18 @@ class SecretSentryScanner:
         context: ScanContext,
         max_findings: int,
     ) -> list[Finding]:
-        """Scan backup archives for secrets."""
+        """Scan backup archives for secrets.
+
+        Args:
+            context: Scan context.
+            max_findings: Maximum findings to return.
+
+        Returns:
+            List of findings from archives.
+        """
         findings: list[Finding] = []
 
+        # Look for archives in backup directories
         backup_dirs = ["backups", "backup"]
         for backup_dir in backup_dirs:
             backup_path = self.config_path / backup_dir
@@ -537,7 +588,15 @@ class SecretSentryScanner:
         archive_path: Path,
         context: ScanContext,
     ) -> list[Finding]:
-        """Scan a single archive file."""
+        """Scan a single archive file.
+
+        Args:
+            archive_path: Path to the archive.
+            context: Scan context.
+
+        Returns:
+            List of findings.
+        """
         findings: list[Finding] = []
         rel_archive = str(archive_path.relative_to(self.config_path))
         total_read = 0
@@ -548,6 +607,7 @@ class SecretSentryScanner:
             """Check archive member content for secrets."""
             lines = content.splitlines()
             for line_num, line in enumerate(lines, start=1):
+                # Check for JWT
                 if JWT_PATTERN.search(line):
                     findings.append(
                         Finding(
@@ -563,8 +623,9 @@ class SecretSentryScanner:
                             tags=["backup", "secrets"],
                         )
                     )
-                    return
+                    return  # One finding per member is enough
 
+                # Check for PEM
                 if PEM_BEGIN_PATTERN.search(line):
                     findings.append(
                         Finding(
@@ -582,6 +643,7 @@ class SecretSentryScanner:
                     )
                     return
 
+                # v3.0: Check for URL userinfo
                 if URL_USERINFO_PATTERN.search(line):
                     findings.append(
                         Finding(
@@ -612,6 +674,7 @@ class SecretSentryScanner:
                         if info.is_dir():
                             continue
 
+                        # Only check text-like files
                         name_lower = info.filename.lower()
                         if not any(name_lower.endswith(ext) for ext in SCANNABLE_EXTENSIONS):
                             continue
@@ -652,14 +715,23 @@ class SecretSentryScanner:
         return findings
 
     def _build_secret_inventory(self, context: ScanContext) -> dict[str, Any]:
-        """Build the secret inventory for reporting."""
+        """Build the secret inventory for reporting.
+
+        Args:
+            context: Scan context after scanning.
+
+        Returns:
+            Secret inventory dictionary.
+        """
         defined_keys = set(context.secrets_map.keys())
         used_keys = context.used_secret_keys
         unused_keys = defined_keys - used_keys
         missing_keys = used_keys - defined_keys
 
+        # Build blast radius (capped)
         blast_radius: dict[str, list[str]] = {}
         for key, locations in context.secret_usage_map.items():
+            # Cap at 10 locations per key
             blast_radius[key] = [f"{f}:{l}" for f, l in locations[:10]]
             if len(locations) > 10:
                 blast_radius[key].append(f"...and {len(locations) - 10} more")
@@ -677,15 +749,31 @@ def create_sanitised_copy(
     output_dir: str,
     options: dict[str, Any] | None = None,
 ) -> tuple[int, list[str]]:
-    """Create a sanitised copy of configuration files."""
+    """Create a sanitised copy of configuration files.
+
+    This replaces detected secrets with ***REDACTED***.
+    v3.0: Also redacts URL userinfo and applies privacy mode.
+
+    Args:
+        config_path: Path to the config directory.
+        output_dir: Path for the sanitised output.
+        options: Scanner options.
+
+    Returns:
+        Tuple of (files_processed, error_list).
+    """
     options = options or {}
     config_root = Path(config_path)
     output_root = Path(output_dir)
 
+    # v3.0: Initialize privacy tokenizer if privacy mode is on
     privacy_mode = options.get(CONF_PRIVACY_MODE_REPORTS, DEFAULT_PRIVACY_MODE_REPORTS)
     tokenizer = PrivacyTokenizer() if privacy_mode else None
+
+    # Create output directory
     output_root.mkdir(parents=True, exist_ok=True)
 
+    # Write warning README
     readme_content = """# SecretSentry Sanitised Configuration Copy
 
 **WARNING**: This directory contains a sanitised copy of your Home Assistant
@@ -703,12 +791,16 @@ Generated: {timestamp}
     files_processed = 0
     errors: list[str] = []
 
+    # Patterns to redact
     sensitive_patterns = [
+        # Key-value patterns
         (
             r'(\b(?:api_key|apikey|token|password|secret|bearer|authorization|client_secret|private_key|access_token|refresh_token|auth_token|webhook|mqtt_password|db_password|database_url|redis_password|mysql_password|postgres_password|encryption_key|jwt_secret)\s*[:=]\s*)["\']?([^"\'\s\n]+)["\']?',
             r'\1"***REDACTED***"',
         ),
+        # JWT tokens
         (r'eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+', '***REDACTED_JWT***'),
+        # Webhook IDs (partial)
         (r'(/api/webhook/)[A-Za-z0-9_-]{8,}', r'\1***REDACTED***'),
     ]
 
@@ -716,17 +808,26 @@ Generated: {timestamp}
         try:
             rel_path = file_path.relative_to(config_root)
             output_path = output_root / rel_path
+
+            # Create parent directories
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
+            # Read and sanitise content
             content = file_path.read_text(encoding="utf-8", errors="ignore")
+
+            # Apply redaction patterns
             sanitised = content
             for pattern, replacement in sensitive_patterns:
                 sanitised = re.sub(pattern, replacement, sanitised, flags=re.IGNORECASE)
 
+            # v3.0: Redact URL userinfo
             sanitised = redact_url_userinfo(sanitised)
+
+            # v3.0: Apply privacy mode if enabled
             if tokenizer:
                 sanitised = tokenizer.apply_privacy_mode(sanitised)
 
+            # Write sanitised file
             output_path.write_text(sanitised, encoding="utf-8")
             files_processed += 1
 
@@ -742,7 +843,17 @@ def export_report_with_privacy(
     scan_result: ScanResult,
     options: dict[str, Any],
 ) -> dict[str, Any]:
-    """Export scan result with privacy mode applied."""
+    """Export scan result with privacy mode applied.
+
+    v3.0: New function for privacy-aware exports.
+
+    Args:
+        scan_result: The scan result to export.
+        options: Options including privacy_mode_reports.
+
+    Returns:
+        Dictionary ready for JSON export.
+    """
     result_dict = scan_result.to_dict()
 
     privacy_mode = options.get(CONF_PRIVACY_MODE_REPORTS, DEFAULT_PRIVACY_MODE_REPORTS)

--- a/custom_components/secretsentry/strings.json
+++ b/custom_components/secretsentry/strings.json
@@ -30,6 +30,7 @@
           "enable_git_subprocess_checks": "Enable git subprocess checks",
           "enable_secret_age": "Check secret age metadata",
           "enable_external_url_self_check": "Enable external URL self-check",
+          "external_url": "Your external URL",
           "privacy_mode_reports": "Privacy mode for reports",
           "enable_env_hygiene": "Environment file hygiene checks",
           "enable_log_scan": "Scan log files for secrets",
@@ -43,6 +44,7 @@
           "enable_git_subprocess_checks": "Run git commands to check if secrets.yaml is tracked (requires git)",
           "enable_secret_age": "Check for old secrets based on date comments in secrets.yaml",
           "enable_external_url_self_check": "Check YOUR OWN external URL for security issues",
+          "external_url": "Required when the external URL self-check is enabled (for example, https://myhome.example.com)",
           "privacy_mode_reports": "Mask private IPs and tokenize hostnames in exported reports",
           "enable_env_hygiene": "Scan .env and docker-compose.yml files for secrets",
           "enable_log_scan": "Scan Home Assistant log files for leaked secrets (may be slow for large logs)"
@@ -99,138 +101,37 @@
   },
   "entity": {
     "sensor": {
-      "total_findings": {
-        "name": "Total Security Findings"
-      },
-      "high_severity_findings": {
-        "name": "High Severity Findings"
-      },
-      "medium_severity_findings": {
-        "name": "Medium Severity Findings"
-      },
-      "low_severity_findings": {
-        "name": "Low Severity Findings"
-      }
+      "total_findings": {"name": "Total Security Findings"},
+      "high_severity_findings": {"name": "High Severity Findings"},
+      "medium_severity_findings": {"name": "Medium Severity Findings"},
+      "low_severity_findings": {"name": "Low Severity Findings"}
     }
   },
   "issues": {
-    "r001": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r002": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r003": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r004": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r005": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r008": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r010": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r011": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r012": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r020": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r021": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r022": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r023": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r030": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r040": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r050": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r060": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r070": {
-      "title": "{title}",
-      "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r071": {
-      "title": "{title}",
-      "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r080": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r090": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r091": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r092": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r093": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "summary": {
-      "title": "{title}",
-      "description": "{description}"
-    }
-  },
-  "services": {
-    "scan_now": {
-      "name": "Scan Now",
-      "description": "Trigger an immediate security scan of the Home Assistant configuration."
-    },
-    "export_report": {
-      "name": "Export Report",
-      "description": "Export a masked JSON report of all findings to /config/secretsentry_report.json. If privacy mode is enabled, IPs and hostnames will also be tokenized."
-    },
-    "export_sanitised_copy": {
-      "name": "Export Sanitised Copy",
-      "description": "Create a sanitised copy of configuration files with secrets replaced by ***REDACTED***. URLs with credentials are also redacted."
-    },
-    "run_selftest": {
-      "name": "Run Self-Test",
-      "description": "Run internal self-tests to verify the scanner is working correctly. Tests all rules, masking, and export functionality."
-    }
+    "r001": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r002": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r003": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r004": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r005": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r008": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r010": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r011": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r012": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r020": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r021": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r022": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r023": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r030": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r040": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r050": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r060": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r070": {"title": "{title}", "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r071": {"title": "{title}", "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r080": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r090": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r091": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r092": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r093": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "summary": {"title": "{title}", "description": "{description}"}
   }
 }

--- a/custom_components/secretsentry/strings.json
+++ b/custom_components/secretsentry/strings.json
@@ -101,10 +101,18 @@
   },
   "entity": {
     "sensor": {
-      "total_findings": {"name": "Total Security Findings"},
-      "high_severity_findings": {"name": "High Severity Findings"},
-      "medium_severity_findings": {"name": "Medium Severity Findings"},
-      "low_severity_findings": {"name": "Low Severity Findings"}
+      "total_findings": {
+        "name": "Total Security Findings"
+      },
+      "high_severity_findings": {
+        "name": "High Severity Findings"
+      },
+      "medium_severity_findings": {
+        "name": "Medium Severity Findings"
+      },
+      "low_severity_findings": {
+        "name": "Low Severity Findings"
+      }
     }
   },
   "issues": {
@@ -124,7 +132,7 @@
     "r030": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
     "r040": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
     "r050": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
-    "r060": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r060": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
     "r070": {"title": "{title}", "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
     "r071": {"title": "{title}", "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
     "r080": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
@@ -133,5 +141,23 @@
     "r092": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
     "r093": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
     "summary": {"title": "{title}", "description": "{description}"}
+  },
+  "services": {
+    "scan_now": {
+      "name": "Scan Now",
+      "description": "Trigger an immediate security scan of the Home Assistant configuration."
+    },
+    "export_report": {
+      "name": "Export Report",
+      "description": "Export a masked JSON report of all findings to /config/secretsentry_report.json. If privacy mode is enabled, IPs and hostnames will also be tokenized."
+    },
+    "export_sanitised_copy": {
+      "name": "Export Sanitised Copy",
+      "description": "Create a sanitised copy of configuration files with secrets replaced by ***REDACTED***. URLs with credentials are also redacted."
+    },
+    "run_selftest": {
+      "name": "Run Self-Test",
+      "description": "Run internal self-tests to verify the scanner is working correctly. Tests all rules, masking, and export functionality."
+    }
   }
 }

--- a/custom_components/secretsentry/translations/en.json
+++ b/custom_components/secretsentry/translations/en.json
@@ -30,6 +30,7 @@
           "enable_git_subprocess_checks": "Enable git subprocess checks",
           "enable_secret_age": "Check secret age metadata",
           "enable_external_url_self_check": "Enable external URL self-check",
+          "external_url": "Your external URL",
           "privacy_mode_reports": "Privacy mode for reports",
           "enable_env_hygiene": "Environment file hygiene checks",
           "enable_log_scan": "Scan log files for secrets",
@@ -43,6 +44,7 @@
           "enable_git_subprocess_checks": "Run git commands to check if secrets.yaml is tracked (requires git)",
           "enable_secret_age": "Check for old secrets based on date comments in secrets.yaml",
           "enable_external_url_self_check": "Check YOUR OWN external URL for security issues",
+          "external_url": "Required when the external URL self-check is enabled (for example, https://myhome.example.com)",
           "privacy_mode_reports": "Mask private IPs and tokenize hostnames in exported reports",
           "enable_env_hygiene": "Scan .env and docker-compose.yml files for secrets",
           "enable_log_scan": "Scan Home Assistant log files for leaked secrets (may be slow for large logs)"
@@ -99,138 +101,43 @@
   },
   "entity": {
     "sensor": {
-      "total_findings": {
-        "name": "Total Security Findings"
-      },
-      "high_severity_findings": {
-        "name": "High Severity Findings"
-      },
-      "medium_severity_findings": {
-        "name": "Medium Severity Findings"
-      },
-      "low_severity_findings": {
-        "name": "Low Severity Findings"
-      }
+      "total_findings": {"name": "Total Security Findings"},
+      "high_severity_findings": {"name": "High Severity Findings"},
+      "medium_severity_findings": {"name": "Medium Severity Findings"},
+      "low_severity_findings": {"name": "Low Severity Findings"}
     }
   },
   "issues": {
-    "r001": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r002": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r003": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r004": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r005": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r008": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r010": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r011": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r012": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r020": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r021": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r022": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r023": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r030": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r040": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r050": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r060": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r070": {
-      "title": "{title}",
-      "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r071": {
-      "title": "{title}",
-      "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r080": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r090": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r091": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r092": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "r093": {
-      "title": "{title}",
-      "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"
-    },
-    "summary": {
-      "title": "{title}",
-      "description": "{description}"
-    }
+    "r001": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r002": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r003": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r004": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r005": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r008": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r010": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r011": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r012": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r020": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r021": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r022": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r023": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r030": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r040": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r050": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r060": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r070": {"title": "{title}", "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r071": {"title": "{title}", "description": "{description}\n\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r080": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r090": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r091": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r092": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Line:** {line}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "r093": {"title": "{title}", "description": "{description}\n\n**File:** {file_path}\n**Evidence:** {evidence}\n\n**Recommendation:** {recommendation}"},
+    "summary": {"title": "{title}", "description": "{description}"}
   },
   "services": {
-    "scan_now": {
-      "name": "Scan Now",
-      "description": "Trigger an immediate security scan of the Home Assistant configuration."
-    },
-    "export_report": {
-      "name": "Export Report",
-      "description": "Export a masked JSON report of all findings to /config/secretsentry_report.json. If privacy mode is enabled, IPs and hostnames will also be tokenized."
-    },
-    "export_sanitised_copy": {
-      "name": "Export Sanitised Copy",
-      "description": "Create a sanitised copy of configuration files with secrets replaced by ***REDACTED***. URLs with credentials are also redacted."
-    },
-    "run_selftest": {
-      "name": "Run Self-Test",
-      "description": "Run internal self-tests to verify the scanner is working correctly. Tests all rules, masking, and export functionality."
-    }
+    "scan_now": {"name": "Scan Now", "description": "Trigger an immediate security scan of the Home Assistant configuration."},
+    "export_report": {"name": "Export Report", "description": "Export a masked JSON report of all findings to /config/secretsentry_report.json. If privacy mode is enabled, IPs and hostnames will also be tokenized."},
+    "export_sanitised_copy": {"name": "Export Sanitised Copy", "description": "Create a sanitised copy of configuration files with secrets replaced by ***REDACTED***. URLs with credentials are also redacted."},
+    "run_selftest": {"name": "Run Self-Test", "description": "Run internal self-tests to verify the scanner is working correctly. Tests all rules, masking, and export functionality."}
   }
 }

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from custom_components.secretsentry.rules import R004SecretRefMissing, ScanContext
+
+
+def make_context():
+    return ScanContext(
+        config_root=Path('.'),
+        secrets_map={'root_key': '***'},
+        secrets_raw_hashes={},
+        used_secret_keys=set(),
+        gitignore_text=None,
+        options={},
+        secret_store_keys={'.': {'root_key'}, 'esphome': {'wifi_key'}},
+    )
+
+
+def test_nested_secret_store_does_not_satisfy_sibling_reference():
+    context = make_context()
+    rule = R004SecretRefMissing()
+    rule.evaluate_file_text('packages/foo.yaml', ['password: !secret wifi_key'], context)
+    findings = rule.evaluate_context(context)
+    assert len(findings) == 1
+    assert findings[0].file_path == 'packages/foo.yaml'
+
+
+def test_nested_secret_store_satisfies_own_subtree_and_root_fallback():
+    context = make_context()
+    rule = R004SecretRefMissing()
+    rule.evaluate_file_text('esphome/device.yaml', [
+        'password: !secret wifi_key',
+        'token: !secret root_key',
+    ], context)
+    assert rule.evaluate_context(context) == []


### PR DESCRIPTION
Addresses #16, #21 and #22; #11 is also covered by the existing v3.0.7 Clear All Repairs flow and will be closed after verification.

- Expose External URL Self-Check and URL settings in the options flow with URL validation.
- Resolve nested `secrets.yaml` stores (including ESPHome) when validating `!secret` references.
- Do not scan `secrets.yaml` itself as an inline-secret leak source.
- Exclude Home Assistant/Nabu Casa managed `.cloud` credential state from user-remediable findings.
- Align manifest ownership, repository links and version metadata to HallyAus/SecretSentry v3.0.8.

Raw secret values are still not retained in the scan context; only masked values and comparison hashes are stored.